### PR TITLE
Accept the operator that's used when filtering

### DIFF
--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -88,7 +88,7 @@ abstract class Adapter implements AdapterInterface
     {
         $attributeName = $attribute->getName();
 
-        $query->andWhere("e.{$attributeName} = :{$attributeName}")
+        $query->andWhere("e.{$attributeName} {$operator} :{$attributeName}")
             ->setParameter($attributeName, $value);
     }
 


### PR DESCRIPTION
The code would assume the filtering was always going to be equals (`=`) - this PR uses the `$operator` parameter to allow for filtering using `>`, `>=`, `<`, `<=`, and `..` as per the [tobyz/json-api-server](https://github.com/tobyzerner/json-api-server) documentation ([here](https://tobyzerner.github.io/json-api-server/filtering.html#filtering)).

This is a duplicate of #1 - I just messed up the merge and had to force push to fix the history.